### PR TITLE
ソースコード中から設定値を消す

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=127.0.0.1
+DB_USER=root
+DB_PASSWORD=password
+DB_NAME=calc_training
+DB_TIMEZONE=jst

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ DB_USER=root
 DB_PASSWORD=password
 DB_NAME=calc_training
 DB_TIMEZONE=jst
+PORT=3000

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 DB_HOST=127.0.0.1
 DB_USER=root
+DB_PORT=3306
 DB_PASSWORD=password
 DB_NAME=calc_training
 DB_TIMEZONE=jst

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,7 @@
     "env": {
         "browser": true,
         "commonjs": true,
+        "node": true,
         "es6": true
     },
     "extends": "eslint:recommended",

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.env
 node_modules/

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+require("dotenv").config();
+
 const app = require("./src/app.js");
 
 app.listen(3000, function () {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@ require("dotenv").config();
 
 const app = require("./src/app.js");
 
-app.listen(3000, function () {
-  console.log("Example app listening on port 3000!");
+// default to port 3000
+const port = process.env.PORT || 3000;
+
+app.listen(port, function () {
+  console.log(`Example app listening on port ${port}!`);
 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.17.2",
+    "dotenv": "^4.0.0",
     "eslint": "^4.0.0",
     "express": "^4.15.3",
     "express-session": "^1.15.3",

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ var bodyParser = require("body-parser");
 const mysql = require("mysql");
 const connection = mysql.createConnection({
   host : process.env.DB_HOST,
+  port : process.env.DB_PORT,
   user : process.env.DB_USER,
   password : process.env.DB_PASSWORD,
   database: process.env.DB_NAME,

--- a/src/app.js
+++ b/src/app.js
@@ -4,11 +4,11 @@ var app = express();
 var bodyParser = require("body-parser");
 const mysql = require("mysql");
 const connection = mysql.createConnection({
-  host : "127.0.0.1",
-  user : "root",
-  password : "password",
-  database: "calc_training",
-  timezone: "jst"
+  host : process.env.DB_HOST,
+  user : process.env.DB_USER,
+  password : process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  timezone: process.env.DB_TIMEZONE,
 });
 app.use(bodyParser.json()); // for parsing application/json
 app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded


### PR DESCRIPTION
ローカルで一人で開発してるうちはだいたい問題ないんですが、たとえば本番サーバとローカルとか、わたしとあなたとか、複数の実行環境で動かすことを考えた際にはソースコード中に設定値が埋め込まれていると困ることがあります。

たとえばDBサーバとアプリケーションサーバは同じではないかもしれません。その場合にhostが127.0.0.1固定だと困ります。
たとえばDBのユーザー・パスワードが違うかもしれません。更にはパスワードが直接埋め込まれた場合は漏洩するリスクが高まります。

こういった事情から、設定値には"環境変数"を使うのがよいとされています。
[The Twelve-Factor App （日本語訳）](https://12factor.net/ja/config)

開発環境において環境変数を容易に使えるようにすることを目的としたdotenvというツールがあります。これはだいたいの言語にあります。
[環境によって変わる設定値はdotenvを使うと便利 - Qiita](http://qiita.com/closer/items/f8d8ba00ae86d7051764)
雑に言うと .env というファイルに `X=Y` と書くと環境変数XにYが格納されるという感じです。

よって今回もcalculation-trainingの設定値を.envに外出ししました。
.env ファイルはクレデンシャルなどを含むことが多いため **git 管理外にしなくてはなりません**。

またどのような設定値が必要かを示すために `.env.example` などのファイルを作っておく、というのがスマートだと(個人的に)思っています。

使うときは `cp .env.example .env` してから使ってください